### PR TITLE
Add option to choose between correlated and uncorrelated outputs in DKL-GPR

### DIFF
--- a/atomai/models/dklgp/dklgpr.py
+++ b/atomai/models/dklgp/dklgpr.py
@@ -128,3 +128,31 @@ class dklGPR(dklGPTrainer):
         data_loader = init_dataloader(x_new, shuffle=False, **kwargs)
         embeded = torch.cat([self._embed(x.to(self.device)) for (x,) in data_loader], 0)
         return embeded.numpy()
+
+    def decode(self, z_emb: Union[torch.Tensor, np.ndarray]) -> Tuple[torch.Tensor]:
+        """
+        "Decodes" the latent space variables into the target space using
+        a trained Gaussian process model (i.e., "GP layer" of DKL-GP)
+        """
+        self.gp_model.eval()
+        m = self.gp_model
+
+        if m.prediction_strategy is None:
+            _ = self._compute_posterior(m.train_inputs[0][:1])
+        pstrategy = m.prediction_strategy.exact_prediction
+
+        z_emb_training = m.feature_extractor(m.train_inputs[0])
+        z_emb, _ = self.set_data(z_emb)
+        z_emb = torch.cat([z_emb, z_emb_training], 0)
+        z_emb = m.scale_to_bounds(z_emb)
+
+        with torch.no_grad(), gpytorch.settings.use_toeplitz(False), gpytorch.settings.fast_pred_var():
+            mean_z = m.mean_module(z_emb)
+            covar_z = m.covar_module(z_emb)
+            full_output = gpytorch.distributions.MultivariateNormal(mean_z, covar_z)
+            full_mean, full_covar = full_output.loc, full_output.lazy_covariance_matrix
+            with gpytorch.settings._use_eval_tolerance():
+                pmean, pcovar = pstrategy(full_mean, full_covar)
+            p = gpytorch.distributions.MultivariateNormal(pmean, pcovar)
+
+        return p.mean.cpu().numpy().T, p.variance.cpu().numpy().T

--- a/test/models/test_dklgpr.py
+++ b/test/models/test_dklgpr.py
@@ -33,6 +33,20 @@ def test_model_predict():
     assert_(isinstance(y_pred[1], np.ndarray))
 
 
+def test_multi_model_predict():
+    indim = 32
+    X = np.random.randn(50, indim)
+    y = np.random.randn(2, 50)
+    X_test = np.random.randn(50, indim)
+    t = dklGPR(indim, shared_embedding_space=False, precision="single")
+    t.fit(X, y)
+    y_pred = t.predict(X_test)
+    assert_equal(y_pred[0].shape, y_pred[1].shape)
+    assert_equal(y_pred[0].shape[1], X.shape[0])
+    assert_(isinstance(y_pred[0], np.ndarray))
+    assert_(isinstance(y_pred[1], np.ndarray))
+
+
 @pytest.mark.parametrize("reg_dim", [1, 2])
 def test_sample_from_posterior(reg_dim):
     indim = 32
@@ -49,6 +63,22 @@ def test_sample_from_posterior(reg_dim):
     assert_(isinstance(samples, np.ndarray))
 
 
+def test_sample_from_multi_model_posterior():
+    indim = 32
+    num_samples = 100
+    X = np.random.randn(50, indim)
+    y = np.random.randn(2, 50)
+    X_test = np.random.randn(50, indim)
+    t = dklGPR(indim, shared_embedding_space=False, precision="single")
+    t.fit(X, y)
+    samples = t.sample_from_posterior(X_test, num_samples)
+    print(samples.shape)
+    assert_equal(samples.shape[0], num_samples)
+    assert_equal(samples.shape[1], 2)
+    assert_equal(samples.shape[2], len(X_test))
+    assert_(isinstance(samples, np.ndarray))
+
+
 @pytest.mark.parametrize("embedim", [1, 2])
 def test_model_embed(embedim):
     indim = 32
@@ -58,8 +88,24 @@ def test_model_embed(embedim):
     t = dklGPR(indim, embedim, precision="single")
     t.fit(X, y)
     y_embedded = t.embed(X_test)
-    assert_equal(y_embedded.shape[0], X.shape[0])
+    assert_equal(y_embedded.shape[0], X_test.shape[0])
     assert_equal(y_embedded.shape[1], embedim)
+    assert_(isinstance(y_embedded, np.ndarray))
+
+
+@pytest.mark.parametrize("embedim", [1, 2])
+def test_multi_model_embed(embedim):
+    indim = 32
+    X = np.random.randn(50, indim)
+    y = np.random.randn(3, 50)
+    X_test = np.random.randn(50, indim)
+    t = dklGPR(indim, embedim, shared_embedding_space=False, precision="single")
+    t.fit(X, y)
+    y_embedded = t.embed(X_test)
+    print(y_embedded.shape)
+    assert_equal(y_embedded.shape[0], 3)
+    assert_equal(y_embedded.shape[1], X_test.shape[0])
+    assert_equal(y_embedded.shape[2], embedim)
     assert_(isinstance(y_embedded, np.ndarray))
 
 

--- a/test/models/test_dklgpr.py
+++ b/test/models/test_dklgpr.py
@@ -61,3 +61,27 @@ def test_model_embed(embedim):
     assert_equal(y_embedded.shape[0], X.shape[0])
     assert_equal(y_embedded.shape[1], embedim)
     assert_(isinstance(y_embedded, np.ndarray))
+
+
+@pytest.mark.parametrize("embedim", [1, 2])
+def test_model_decode_scalar(embedim):
+    indim = 32
+    X = np.random.randn(50, indim)
+    y = np.random.randn(50)
+    t = dklGPR(indim, embedim, precision="single")
+    t.fit(X, y)
+    z = np.random.randn(2, embedim)
+    decoded = t.decode(z)
+    assert_equal(decoded[0].shape, (2, 1))
+
+
+@pytest.mark.parametrize("embedim", [1, 2])
+def test_model_decode_vector(embedim):
+    indim = 32
+    X = np.random.randn(50, indim)
+    y = np.random.randn(3, 50)
+    t = dklGPR(indim, embedim, precision="single")
+    t.fit(X, y)
+    z = np.random.randn(2, embedim)
+    decoded = t.decode(z)
+    assert_equal(decoded[0].shape, (2, 3))

--- a/test/trainers/test_gptrainer.py
+++ b/test/trainers/test_gptrainer.py
@@ -43,6 +43,16 @@ def test_trainer_compiler():
     assert_(t.likelihood is not None)
 
 
+def test_multi_model_trainer_compiler():
+    indim = 32
+    X = np.random.randn(50, indim)
+    y = np.random.randn(2, 50)
+    t = dklGPTrainer(indim, shared_embedding_space=False, precision="single")
+    t.compile_multi_model_trainer(X, y, 2)
+    assert_(t.gp_model is not None)
+    assert_(t.likelihood is not None)
+
+
 def test_trainer_train():
     indim = 32
     X = np.random.randn(50, indim)
@@ -50,10 +60,25 @@ def test_trainer_train():
     t = dklGPTrainer(indim, precision="single")
     t.compile_trainer(X, y)
     w_init = dc(t.gp_model.feature_extractor.state_dict())
-    X_, y_ = t.set_data(X, y)
-    t.train_step(X_, y_)
+    t.train_step()
     w_final = t.gp_model.feature_extractor.state_dict()
     assert_(not weights_equal(w_init, w_final))
+
+
+def test_multi_model_trainer_train():
+    indim = 32
+    X = np.random.randn(50, indim)
+    y = np.random.randn(2, 50)
+    t = dklGPTrainer(indim, shared_embedding_space=False, precision="single")
+    t.compile_multi_model_trainer(X, y)
+    w_init1 = dc(t.gp_model.models[0].feature_extractor.state_dict())
+    w_init2 = dc(t.gp_model.models[1].feature_extractor.state_dict())
+    t.train_step()
+    w_final1 = t.gp_model.models[0].feature_extractor.state_dict()
+    w_final2 = t.gp_model.models[1].feature_extractor.state_dict()
+    assert_(not weights_equal(w_final1, w_final2))
+    assert_(not weights_equal(w_init1, w_final1))
+    assert_(not weights_equal(w_init2, w_final2))
 
 
 def test_trainer_train_freeze_w():
@@ -63,8 +88,7 @@ def test_trainer_train_freeze_w():
     t = dklGPTrainer(indim, precision="single")
     t.compile_trainer(X, y, freeze_weights=True)
     w_init = dc(t.gp_model.feature_extractor.state_dict())
-    X_, y_ = t.set_data(X, y)
-    t.train_step(X_, y_)
+    t.train_step()
     w_final = t.gp_model.feature_extractor.state_dict()
     assert_(weights_equal(w_init, w_final))
 


### PR DESCRIPTION
Summary of the PR:
- In the previous implementation of DKL for vector-valued target function (e.g. spectra), all the models in the GP layer shared the same latent space inducing a correlation between outputs.
- This PR allows one to choose between 2 options: i) a shared latent space for all the outputs (induced correlation between outputs), and ii) a separate latent space for each output (completely independent outputs). In the latter case, we train in parallel an ensemble of deep neural networks where the number of models in the ensemble is equal to the number of target outputs (e.g., for spectral data with 128 points, we will train 128 neural networks).
- To choose between correlated and uncorrelated outputs, use the boolean argument ```shared_embedding_space``` when initializing the dklGPR.