### PR TITLE
Add ensemble DKL and notebook with example

### DIFF
--- a/atomai/models/dklgp/dklgpr.py
+++ b/atomai/models/dklgp/dklgpr.py
@@ -82,7 +82,8 @@ class dklGPR(dklGPTrainer):
 
         Keyword Args:
             feature_extractor:
-                (Optional) Custom neural network for feature extractor
+                (Optional) Custom neural network for feature extractor.
+                Must take input/feature dims and embedding dims as its arguments.
             freeze_weights:
                 Freezes weights of feature extractor, that is, they are not
                 passed to the optimizer. Used for a transfer learning.
@@ -98,7 +99,7 @@ class dklGPR(dklGPTrainer):
                      **kwargs: Union[Type[torch.nn.Module], bool, float]
                      ) -> None:
         """
-        Initializes and trains a deep kernel GP model
+        Initializes and trains an ensemble of deep kernel GP model
 
         Args:
             X: Input training data (aka features) of N x input_dim dimensions
@@ -108,7 +109,8 @@ class dklGPR(dklGPTrainer):
 
         Keyword Args:
             feature_extractor:
-                (Optional) Custom neural network for feature extractor
+                (Optional) Custom neural network for feature extractor.
+                Must take input/feature dims and embedding dims as its arguments.
             freeze_weights:
                 Freezes weights of feature extractor, that is, they are not
                 passed to the optimizer. Used for a transfer learning.

--- a/atomai/models/dklgp/dklgpr.py
+++ b/atomai/models/dklgp/dklgpr.py
@@ -91,6 +91,44 @@ class dklGPR(dklGPTrainer):
         """
         _ = self.run(X, y, training_cycles, **kwargs)
 
+    def fit_ensemble(self, X: Union[torch.Tensor, np.ndarray],
+                     y: Union[torch.Tensor, np.ndarray],
+                     training_cycles: int = 1,
+                     n_models: int = 5,
+                     **kwargs: Union[Type[torch.nn.Module], bool, float]
+                     ) -> None:
+        """
+        Initializes and trains a deep kernel GP model
+
+        Args:
+            X: Input training data (aka features) of N x input_dim dimensions
+            y: Output targets of batch_size x N or N (if batch_size=1) dimensions
+            training_cycles: Number of training epochs
+            n_models: Number of models in ensemble
+
+        Keyword Args:
+            feature_extractor:
+                (Optional) Custom neural network for feature extractor
+            freeze_weights:
+                Freezes weights of feature extractor, that is, they are not
+                passed to the optimizer. Used for a transfer learning.
+            lr: learning rate (Default: 0.01)
+            print_loss: print loss at every n-th training cycle (epoch)
+        """
+        if y.ndim == 1:
+            y = y[None]
+        if y.shape[0] > 1:
+            raise NotImplementedError(
+                "The ensemble training is currently supported only for scalar targets")
+        y = y.repeat(n_models, 0) if isinstance(y, np.ndarray) else y.repeat(n_models, 1)
+        if self.correlated_output:
+            msg = ("Replacing shared independent embedding space with" +
+                   " {} independent ones").format(n_models)
+            warnings.warn(msg)
+            self.correlated_output = False
+        self.ensemble = True
+        _ = self.run(X, y, training_cycles, **kwargs)
+
     def _compute_posterior(self, X: torch.Tensor) -> Union[mvn_, List[mvn_]]:
         """
         Computes the posterior over model outputs at the provided points (X).
@@ -194,7 +232,7 @@ class dklGPR(dklGPTrainer):
         x_new, _ = self.set_data(x_new, device='cpu')
         data_loader = init_dataloader(x_new, shuffle=False, **kwargs)
         embeded = torch.cat([self._embed(x.to(self.device)) for (x,) in data_loader], 0)
-        if not self.correlated_output:
+        if not self.correlated_output and not self.ensemble:
             embeded = embeded.permute(-1, 0, 1)
         return embeded.numpy()
 

--- a/atomai/trainers/gptrainer.py
+++ b/atomai/trainers/gptrainer.py
@@ -93,6 +93,8 @@ class dklGPTrainer:
         the number of neural networks is equal to the number of Gaussian
         processes. For example, if the outputs are spectra of length 128,
         one will have 128 neural networks and 128 GPs trained in parallel.
+        It can be also used for training an ensembles of models for the same
+        scalar output.
         """
         if self.correlated_output:
             raise NotImplementedError(
@@ -160,7 +162,8 @@ class dklGPTrainer:
 
         Keyword Args:
             feature_extractor:
-                (Optional) Custom neural network for feature extractor
+                (Optional) Custom neural network for feature extractor.
+                Must take input/feature dims and embedding dims as its arguments.
             grid_size:
                 Grid size for structured kernel interpolation (Default: 50)
             freeze_weights:
@@ -174,9 +177,8 @@ class dklGPTrainer:
                 "use compile_multi_model_trainer(*args, **kwargs)")
         X, y = self.set_data(X, y)
         input_dim, embedim = self.dimdict["input_dim"], self.dimdict["embedim"]
-        feature_extractor = kwargs.get("feature_extractor")
-        if feature_extractor is None:
-            feature_extractor = fcFeatureExtractor(input_dim, embedim)
+        feature_net = kwargs.get("feature_extractor", fcFeatureExtractor)
+        feature_extractor = feature_net(input_dim, embedim)
         freeze_weights = kwargs.get("freeze_weights", False)
         if freeze_weights:
             for p in feature_extractor.parameters():

--- a/test/models/test_dklgpr.py
+++ b/test/models/test_dklgpr.py
@@ -19,6 +19,16 @@ def test_model_fit():
     assert_equal(len(t.train_loss), 2)
 
 
+@pytest.mark.parametrize("shared_emb", [0, 1])
+def test_model_fit_ensemble(shared_emb):
+    indim = 32
+    X = np.random.randn(50, indim)
+    y = np.random.randn(50)
+    t = dklGPR(indim, precision="single", shared_embedding_space=shared_emb)
+    assert_equal(len(t.train_loss), 0)
+    t.fit_ensemble(X, y, 2, n_models=3)
+    assert_equal(len(t.train_loss), 2)
+
 def test_model_predict():
     indim = 32
     X = np.random.randn(50, indim)
@@ -43,6 +53,24 @@ def test_multi_model_predict():
     y_pred = t.predict(X_test)
     assert_equal(y_pred[0].shape, y_pred[1].shape)
     assert_equal(y_pred[0].shape[1], X.shape[0])
+    assert_(isinstance(y_pred[0], np.ndarray))
+    assert_(isinstance(y_pred[1], np.ndarray))
+
+
+@pytest.mark.parametrize("shared_emb", [0, 1])
+@pytest.mark.parametrize("ydim", [(50,), (1, 50)])
+def test_ensemble_predict(shared_emb, ydim):
+    indim = 32
+    n_models = 3
+    X = np.random.randn(50, indim)
+    y = np.random.randn(*ydim)
+    X_test = np.random.randn(50, indim)
+    t = dklGPR(indim, shared_embedding_space=shared_emb, precision="single")
+    t.fit_ensemble(X, y, 1, n_models=n_models)
+    y_pred = t.predict(X_test)
+    assert_equal(y_pred[0].shape, y_pred[1].shape)
+    assert_equal(y_pred[0].shape[1], X.shape[0])
+    assert_equal(y_pred[0].shape[0], n_models)
     assert_(isinstance(y_pred[0], np.ndarray))
     assert_(isinstance(y_pred[1], np.ndarray))
 

--- a/test/trainers/test_gptrainer.py
+++ b/test/trainers/test_gptrainer.py
@@ -103,6 +103,18 @@ def test_trainer_compile_and_run():
     assert_equal(len(t.train_loss), 3)
 
 
+def test_ensemble_trainer_compile_and_run():
+    indim = 32
+    X = np.random.randn(50, indim)
+    y = np.random.randn(1, 50).repeat(3, axis=0)
+    t = dklGPTrainer(indim, precision="single", shared_embedding_space=False)
+    t.ensemble = True
+    t.compile_multi_model_trainer(X, y)
+    w1 = t.gp_model.models[0].state_dict()
+    w2 = t.gp_model.models[2].state_dict()
+    assert_(not weights_equal(w1, w2))
+
+
 def test_trainer_run():
     indim = 32
     X = np.random.randn(50, indim)


### PR DESCRIPTION
- Add ensemble DKL as a compromise between the fully Bayesian DKL and the vanilla DKL (used up to date)
- Add example notebook for DKL (reconstruction and active learning with Thompson sampler) based on plasmonic dataset