### PR TITLE
Updates to graph class (px2ang and max_neighbors are added)

### DIFF
--- a/atomai/utils/graphx.py
+++ b/atomai/utils/graphx.py
@@ -87,6 +87,10 @@ class Graph:
         Identifies neighbors of each graph node
 
         Args:
+            **max_neighbors(int):
+                This is the maximum number of neighbors each node can have, 
+                ususally used to form the graph with only nearest neighbors
+                Default is -1 which means it will find all the neighbors
             **expand (float):
                 coefficient determining the maximum allowable expansion of
                 atomic bonds when constructing a graph. For example, the two
@@ -97,6 +101,7 @@ class Graph:
             del v.neighbors[:]
         Rij = get_interatomic_r
         e = kwargs.get("expand", 1.2)
+        max_neighbors = kwargs.get("max_neighbors", -1)
         tree = spatial.cKDTree(self.coordinates[:, :3])
         uval = np.unique(self.coordinates[:, -1])
         if len(uval) == 1:
@@ -105,8 +110,9 @@ class Graph:
             for v, nn in zip(self.vertices, neighbors):
                 for n in nn:
                     if self.vertices[n] != v:
-                        v.neighbors.append(self.vertices[n])
-                        v.neighborscopy.append(self.vertices[n])
+                        if max_neighbors==-1 or len(v.neighbors)<max_neighbors:
+                            v.neighbors.append(self.vertices[n])
+                            v.neighborscopy.append(self.vertices[n])
         else:
             uval = [self.map_dict[u] for u in uval]
             apairs = [(p[0], p[1]) for p in itertools.product(uval, repeat=2)]
@@ -122,8 +128,9 @@ class Graph:
                         eucldist = np.linalg.norm(
                             coords[:3] - coords2[:3])
                         if eucldist <= rij[(atom1, atom2)]:
-                            v.neighbors.append(self.vertices[n])
-                            v.neighborscopy.append(self.vertices[n])
+                            if max_neighbors==-1 or len(v.neighbors)<max_neighbors:
+                                v.neighbors.append(self.vertices[n])
+                                v.neighborscopy.append(self.vertices[n])
 
     def find_rings(self,
                    v: Type[Node],

--- a/atomai/utils/graphx.py
+++ b/atomai/utils/graphx.py
@@ -127,7 +127,7 @@ class Graph:
                 if max_neighbors == -1:
                     nn = tree.query_ball_point(coords[:3], r=rmax)
                 else:
-                    _, nn = tree.query(self.coordinates[:, :3], k=max_neighbors+1, distance_upper_bound = rmax)
+                    _, nn = tree.query(coords[:3], k=max_neighbors+1, distance_upper_bound = rmax)
                 for n, coords2 in zip(nn, self.coordinates[nn]):
                     if self.vertices[n] != v:
                         atom2 = self.map_dict[coords2[-1]]

--- a/atomai/utils/graphx.py
+++ b/atomai/utils/graphx.py
@@ -129,8 +129,10 @@ class Graph:
                     nn = tree.query_ball_point(coords[:3], r=rmax)
                 else:
                     _, nn = tree.query(coords[:3], k=max_neighbors+1, distance_upper_bound = rmax)
-                if not n >= len(self.vertices):
-                    for n, coords2 in zip(nn, self.coordinates[nn]):
+                
+                for n in nn:
+                    if not n >= len(self.vertices):
+                        coords2 = self.coordinates[nn]
                         if self.vertices[n] != v:
                             atom2 = self.map_dict[coords2[-1]]
                             eucldist = np.linalg.norm(

--- a/atomai/utils/graphx.py
+++ b/atomai/utils/graphx.py
@@ -112,9 +112,10 @@ class Graph:
                 _, neighbors = tree.query(self.coordinates[:, :3], k=max_neighbors+1, distance_upper_bound = rmax)
             for v, nn in zip(self.vertices, neighbors):
                 for n in nn:
-                    if self.vertices[n] != v:
-                        v.neighbors.append(self.vertices[n])
-                        v.neighborscopy.append(self.vertices[n])
+                    if not n >= len(self.vertices):
+                        if self.vertices[n] != v:
+                            v.neighbors.append(self.vertices[n])
+                            v.neighborscopy.append(self.vertices[n])
                 
         else:
             uval = [self.map_dict[u] for u in uval]
@@ -129,12 +130,12 @@ class Graph:
                 else:
                     _, nn = tree.query(coords[:3], k=max_neighbors+1, distance_upper_bound = rmax)
                 for n, coords2 in zip(nn, self.coordinates[nn]):
-                    if self.vertices[n] != v:
-                        atom2 = self.map_dict[coords2[-1]]
-                        eucldist = np.linalg.norm(
-                            coords[:3] - coords2[:3])
-                        if eucldist <= rij[(atom1, atom2)]:
-                            if max_neighbors==-1 or len(v.neighbors)<max_neighbors:
+                    if not n >= len(self.vertices):
+                        if self.vertices[n] != v:
+                            atom2 = self.map_dict[coords2[-1]]
+                            eucldist = np.linalg.norm(
+                                coords[:3] - coords2[:3])
+                            if eucldist <= rij[(atom1, atom2)]:
                                 v.neighbors.append(self.vertices[n])
                                 v.neighborscopy.append(self.vertices[n])
 

--- a/atomai/utils/graphx.py
+++ b/atomai/utils/graphx.py
@@ -132,7 +132,7 @@ class Graph:
                 
                 for n in nn:
                     if not n >= len(self.vertices):
-                        coords2 = self.coordinates[nn]
+                        coords2 = self.coordinates[n]
                         if self.vertices[n] != v:
                             atom2 = self.map_dict[coords2[-1]]
                             eucldist = np.linalg.norm(

--- a/atomai/utils/graphx.py
+++ b/atomai/utils/graphx.py
@@ -138,7 +138,20 @@ class Graph:
                             if eucldist <= rij[(atom1, atom2)]:
                                 v.neighbors.append(self.vertices[n])
                                 v.neighborscopy.append(self.vertices[n])
-
+        
+        #Making the graph symmetric when max_neighbors is used
+        for v in self.vertices:
+            id = v.id
+            rem_ids = []
+            for nn in v.neighbors:
+                nn_neighbors_list = [nn.neighbors[l].id for l in range(len(nn.neighbors))]
+                if id not in nn_neighbors_list:
+                    rem_ids.append(nn)
+    
+            for rem_id in rem_ids:
+                v.neighbors.remove(rem_id)
+            
+            
     def find_rings(self,
                    v: Type[Node],
                    rings: List[List[Type[Node]]] = [],

--- a/atomai/utils/graphx.py
+++ b/atomai/utils/graphx.py
@@ -106,7 +106,7 @@ class Graph:
         uval = np.unique(self.coordinates[:, -1])
         if len(uval) == 1:
             rmax = Rij([self.map_dict[uval[0]], self.map_dict[uval[0]]], e)
-            neighbors = tree.query_ball_point(self.coordinates[:, :3], r=rmax)
+            neighbors = tree.query_ball_point(self.coordinates[:, :3], r=rmax, return_sorted = True)
             for v, nn in zip(self.vertices, neighbors):
                 for n in nn:
                     if self.vertices[n] != v:
@@ -121,7 +121,7 @@ class Graph:
             rij = dict(zip(apairs, rij))
             for v, coords in zip(self.vertices, self.coordinates):
                 atom1 = self.map_dict[coords[-1]]
-                nn = tree.query_ball_point(coords[:3], r=rmax)
+                nn = tree.query_ball_point(coords[:3], r=rmax, return_sorted = True)
                 for n, coords2 in zip(nn, self.coordinates[nn]):
                     if self.vertices[n] != v:
                         atom2 = self.map_dict[coords2[-1]]

--- a/atomai/utils/graphx.py
+++ b/atomai/utils/graphx.py
@@ -129,8 +129,8 @@ class Graph:
                     nn = tree.query_ball_point(coords[:3], r=rmax)
                 else:
                     _, nn = tree.query(coords[:3], k=max_neighbors+1, distance_upper_bound = rmax)
-                for n, coords2 in zip(nn, self.coordinates[nn]):
-                    if not n >= len(self.vertices):
+                if not n >= len(self.vertices):
+                    for n, coords2 in zip(nn, self.coordinates[nn]):
                         if self.vertices[n] != v:
                             atom2 = self.map_dict[coords2[-1]]
                             eucldist = np.linalg.norm(

--- a/atomai/utils/graphx.py
+++ b/atomai/utils/graphx.py
@@ -106,13 +106,16 @@ class Graph:
         uval = np.unique(self.coordinates[:, -1])
         if len(uval) == 1:
             rmax = Rij([self.map_dict[uval[0]], self.map_dict[uval[0]]], e)
-            neighbors = tree.query_ball_point(self.coordinates[:, :3], r=rmax, return_sorted = True)
+            if max_neighbors == -1:
+                neighbors = tree.query_ball_point(self.coordinates[:, :3], r=rmax)
+            else:
+                _, neighbors = tree.query(self.coordinates[:, :3], k=max_neighbors+1, distance_upper_bound = rmax)
             for v, nn in zip(self.vertices, neighbors):
                 for n in nn:
                     if self.vertices[n] != v:
-                        if max_neighbors==-1 or len(v.neighbors)<max_neighbors:
-                            v.neighbors.append(self.vertices[n])
-                            v.neighborscopy.append(self.vertices[n])
+                        v.neighbors.append(self.vertices[n])
+                        v.neighborscopy.append(self.vertices[n])
+                
         else:
             uval = [self.map_dict[u] for u in uval]
             apairs = [(p[0], p[1]) for p in itertools.product(uval, repeat=2)]
@@ -121,7 +124,10 @@ class Graph:
             rij = dict(zip(apairs, rij))
             for v, coords in zip(self.vertices, self.coordinates):
                 atom1 = self.map_dict[coords[-1]]
-                nn = tree.query_ball_point(coords[:3], r=rmax, return_sorted = True)
+                if max_neighbors == -1:
+                    nn = tree.query_ball_point(coords[:3], r=rmax)
+                else:
+                    _, nn = tree.query(self.coordinates[:, :3], k=max_neighbors+1, distance_upper_bound = rmax)
                 for n, coords2 in zip(nn, self.coordinates[nn]):
                     if self.vertices[n] != v:
                         atom2 = self.map_dict[coords2[-1]]


### PR DESCRIPTION
--Added px2ang argument for the graph class. 
    For finding the neighbors, coordinates in Angstroms are used, and for making nx_graph, coordinates in pixel units are used so that the plots make sense. 

--Added max_neighbors as a kwargs argument to the find_neighbors method in the graph class.
    When set to -1 (default value), the method works like the one in the previous version.
    When set to any other values, the number of neighbors for each node is cut off at the 'max_neighbors.'
    Additional care is also taken to avoid unidirectional edges. An edge is formed only when the nodes are connected to each other after satisfying the 'max_neighbors' argument from both sides. 
