### PR TITLE
`ptp` was removed from the ndarray class in NumPy 2.0. Use np.ptp(arr, ...) instead.

### DIFF
--- a/atomai/utils/preproc.py
+++ b/atomai/utils/preproc.py
@@ -757,7 +757,7 @@ def torch_format_image(image_data: np.ndarray,
     else:
         pass
     if norm:
-        image_data = (image_data - image_data.min()) / image_data.ptp()
+        image_data = (image_data - image_data.min()) / np.ptp(image_data)#image_data.ptp()
     image_data = torch.from_numpy(image_data).float()
     return image_data
 
@@ -786,7 +786,7 @@ def torch_format_spectra(spectra: np.ndarray,
     else:
         pass
     if norm:
-        spectra = (spectra - spectra.min()) / spectra.ptp()
+        spectra = (spectra - spectra.min()) / np.ptp(spectra)#spectra.ptp()
     spectra = torch.from_numpy(spectra).float()
     return spectra
 


### PR DESCRIPTION
Found this error on colab while running: https://github.com/pycroscopy/atomai/blob/master/examples/notebooks/AtomicSemanticSegmention.ipynb

